### PR TITLE
feat: Cabecera Content-Disposition

### DIFF
--- a/src/main/java/com/gateway/config/CorsConfig.java
+++ b/src/main/java/com/gateway/config/CorsConfig.java
@@ -18,6 +18,7 @@ public class CorsConfig {
 
         corsConfig.addAllowedMethod("*");
         corsConfig.addAllowedHeader("*");
+        corsConfig.addExposedHeader("Content-Disposition");
 
         corsConfig.setAllowCredentials(true);
         corsConfig.setMaxAge(3600L);


### PR DESCRIPTION
Al añadir `addExposedHeader("Content-Disposition")`, le estamos diciendo explícitamente al navegador que permita que el código JavaScript del frontend acceda a esta cabecera en particular y permita leer los nombres de archivos exportados desde el backend.